### PR TITLE
Load README SVG badges over HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Better Align
 
-[![Current Version](http://vsmarketplacebadge.apphb.com/version-short/wwm.better-align.svg)](https://marketplace.visualstudio.com/items?itemName=wwm.better-align)
-[![Install Count](http://vsmarketplacebadge.apphb.com/installs-short/wwm.better-align.svg)](https://marketplace.visualstudio.com/items?itemName=wwm.better-align)
-[![Rating](http://vsmarketplacebadge.apphb.com/rating-short/wwm.better-align.svg)](https://marketplace.visualstudio.com/items?itemName=wwm.better-align)
+[![Current Version](https://vsmarketplacebadge.apphb.com/version-short/wwm.better-align.svg)](https://marketplace.visualstudio.com/items?itemName=wwm.better-align)
+[![Install Count](https://vsmarketplacebadge.apphb.com/installs-short/wwm.better-align.svg)](https://marketplace.visualstudio.com/items?itemName=wwm.better-align)
+[![Rating](https://vsmarketplacebadge.apphb.com/rating-short/wwm.better-align.svg)](https://marketplace.visualstudio.com/items?itemName=wwm.better-align)
 
 ## Features
 


### PR DESCRIPTION
Both seem to work equally well:

![Current Version](http://vsmarketplacebadge.apphb.com/version-short/wwm.better-align.svg)

![Current Version](https://vsmarketplacebadge.apphb.com/version-short/wwm.better-align.svg)

However some validation scripts don't like images loaded of insecure `http://`, like for example https://github.com/open-vsx/publish-extensions/issues/53 (while trying to re-publish `wwm.better-align` to [Open VSX](https://open-vsx.org))